### PR TITLE
Add SAMUS MoE model support

### DIFF
--- a/blsamustinyMoe/networks/models/model_dict.py
+++ b/blsamustinyMoe/networks/models/model_dict.py
@@ -1,28 +1,41 @@
 from models.segment_anything.build_sam import sam_model_registry
 from models.segment_anything_samus.build_sam_us import samus_model_registry
+from models.segment_anything_samus_moe.build_moesamus import moesamus_model_registry
 import torchvision.models as models
 import torch
 import timm
+
+
 def get_model(modelname="SAM", args=None, opt=None):
     if modelname == "SAM":
-        model = sam_model_registry['vit_b'](checkpoint=args.sam_ckpt)
+        model = sam_model_registry["vit_b"](checkpoint=args.sam_ckpt)
     elif modelname == "SAMUS":
-        model = samus_model_registry['vit_b'](args=args, checkpoint=args.sam_ckpt)
+        model = samus_model_registry["vit_b"](args=args, checkpoint=args.sam_ckpt)
+    elif modelname == "SAMUSMOE":
+        model = moesamus_model_registry["vit_t"](
+            args=args,
+            checkpoint=args.sam_ckpt,
+            vit_checkpint=getattr(args, "tiny_vit_ckpt", None),
+        )
     else:
         raise RuntimeError("Could not find the model:", modelname)
     return model
 
+
 def get_classifier(opt=None):
-    if opt.classifier_name =="Resnet18":
+    if opt.classifier_name == "Resnet18":
         assert opt.classifier_size == 256, "图像尺寸需要为256"
         classifier = models.resnet18(pretrained=True)
-        classifier.fc = torch.nn.Linear(classifier.fc.in_features, opt.classifier_classes)
-    elif opt.classifier_name =="Vit":
+        classifier.fc = torch.nn.Linear(
+            classifier.fc.in_features, opt.classifier_classes
+        )
+    elif opt.classifier_name == "Vit":
         # classifier = models.VisionTransformer(image_size=args.img_size,patch_size=16,num_layers=4,num_heads=4,hidden_dim=768,mlp_dim=3072,num_classes=args.classifier_classes)
         assert opt.classifier_size == 224, "图像尺寸需要为224"
         classifier = timm.models.vit_base_patch16_224(pretrained=True)
-        classifier.head = torch.nn.Linear(classifier.head.in_features, opt.classifier_classes)
-
+        classifier.head = torch.nn.Linear(
+            classifier.head.in_features, opt.classifier_classes
+        )
     else:
         raise RuntimeError("Could not find the classifier:", opt.classifier_name)
     return classifier

--- a/blsamustinyMoe/omni_test.py
+++ b/blsamustinyMoe/omni_test.py
@@ -16,10 +16,11 @@ from datasets.dataset import USdatasetCls, USdatasetSeg
 
 from utils import omni_seg_test
 from sklearn.metrics import accuracy_score
-# 在文件开头添加
-USE_SAMUS = True  # 与训练时保持一致
 
-if USE_SAMUS:
+# 与训练脚本保持一致，默认使用带 MoE 的 SAMUS
+USE_SAMUS_MOE = True
+
+if USE_SAMUS_MOE:
     from networks.samus_adapter import SAMUSAdapter as ModelClass
 else:
     from networks.omni_vision_transformer import OmniVisionTransformer as ModelClass

--- a/blsamustinyMoe/omni_train.py
+++ b/blsamustinyMoe/omni_train.py
@@ -4,10 +4,11 @@ import random
 import numpy as np
 import torch
 import torch.backends.cudnn as cudnn
-# 选择使用的模型
-USE_SAMUS = True  # 设置为 True 使用 SAMUS，False 使用原始 ViT_omni
 
-if USE_SAMUS:
+# 选择使用的模型
+USE_SAMUS_MOE = True  # True 使用带 MoE 的 SAMUS，False 使用原始 ViT_omni
+
+if USE_SAMUS_MOE:
     from networks.samus_adapter import SAMUSAdapter as ModelClass
 else:
     from networks.omni_vision_transformer import OmniVisionTransformer as ModelClass


### PR DESCRIPTION
## Summary
- register MoE-enhanced SAMUS model in model dictionary
- default training and inference scripts to use SAMUS MoE adapter

## Testing
- `python -m py_compile blsamustinyMoe/networks/models/model_dict.py blsamustinyMoe/omni_train.py blsamustinyMoe/omni_test.py`


------
https://chatgpt.com/codex/tasks/task_e_689b2a125334832b87874efc5e9c96a5