### PR TITLE
Implement MoE adapters for Tiny SAMUS

### DIFF
--- a/blsamustinyMoe/networks/models/model_dict.py
+++ b/blsamustinyMoe/networks/models/model_dict.py
@@ -1,28 +1,41 @@
 from models.segment_anything.build_sam import sam_model_registry
 from models.segment_anything_samus.build_sam_us import samus_model_registry
+from models.segment_anything_samus_moe.build_moesamus import moesamus_model_registry
 import torchvision.models as models
 import torch
 import timm
+
+
 def get_model(modelname="SAM", args=None, opt=None):
     if modelname == "SAM":
-        model = sam_model_registry['vit_b'](checkpoint=args.sam_ckpt)
+        model = sam_model_registry["vit_b"](checkpoint=args.sam_ckpt)
     elif modelname == "SAMUS":
-        model = samus_model_registry['vit_b'](args=args, checkpoint=args.sam_ckpt)
+        model = samus_model_registry["vit_b"](args=args, checkpoint=args.sam_ckpt)
+    elif modelname == "SAMUSMOE":
+        model = moesamus_model_registry["vit_t"](
+            args=args,
+            checkpoint=args.sam_ckpt,
+            vit_checkpint=getattr(args, "tiny_vit_ckpt", None),
+        )
     else:
         raise RuntimeError("Could not find the model:", modelname)
     return model
 
+
 def get_classifier(opt=None):
-    if opt.classifier_name =="Resnet18":
+    if opt.classifier_name == "Resnet18":
         assert opt.classifier_size == 256, "图像尺寸需要为256"
         classifier = models.resnet18(pretrained=True)
-        classifier.fc = torch.nn.Linear(classifier.fc.in_features, opt.classifier_classes)
-    elif opt.classifier_name =="Vit":
+        classifier.fc = torch.nn.Linear(
+            classifier.fc.in_features, opt.classifier_classes
+        )
+    elif opt.classifier_name == "Vit":
         # classifier = models.VisionTransformer(image_size=args.img_size,patch_size=16,num_layers=4,num_heads=4,hidden_dim=768,mlp_dim=3072,num_classes=args.classifier_classes)
         assert opt.classifier_size == 224, "图像尺寸需要为224"
         classifier = timm.models.vit_base_patch16_224(pretrained=True)
-        classifier.head = torch.nn.Linear(classifier.head.in_features, opt.classifier_classes)
-
+        classifier.head = torch.nn.Linear(
+            classifier.head.in_features, opt.classifier_classes
+        )
     else:
         raise RuntimeError("Could not find the classifier:", opt.classifier_name)
     return classifier

--- a/blsamustinyMoe/networks/models/segment_anything_samus_moe/modeling/__init__.py
+++ b/blsamustinyMoe/networks/models/segment_anything_samus_moe/modeling/__init__.py
@@ -11,3 +11,6 @@ from .prompt_encoder import PromptEncoder
 from .transformer import TwoWayTransformer
 from .Auto_Prompt_Generator import AutoPromptGenerator
 from .tiny_vit_sam import TinyViT
+from .moe_layers import Router, MoEAdapter
+from .moe_samus import MoESamus
+

--- a/blsamustinyMoe/networks/models/segment_anything_samus_moe/modeling/moe_layers.py
+++ b/blsamustinyMoe/networks/models/segment_anything_samus_moe/modeling/moe_layers.py
@@ -23,7 +23,7 @@ class DropPath(nn.Module):
 
 
 class Router(nn.Module):
-    """Gating mechanism for MoE."""
+    """Simple linear router that produces routing scores."""
 
     def __init__(self, dim: int, num_experts: int, temperature: float = 1.0) -> None:
         super().__init__()
@@ -31,10 +31,7 @@ class Router(nn.Module):
         self.temperature = temperature
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        logits = self.linear(x) / self.temperature
-        if self.training:
-            logits = logits + torch.randn_like(logits) * 0.5
-        return logits
+        return self.linear(x) / self.temperature
 
 
 class MoEFFN(nn.Module):
@@ -65,15 +62,16 @@ class MoEFFN(nn.Module):
         logits = self.router(x)
         probs = F.softmax(logits, dim=-1)
         if self.training:
-            idx = torch.multinomial(probs.view(-1, self.num_experts), 1)
-            idx = idx.view(probs.shape[:-1])
+            topk = torch.multinomial(probs.view(-1, self.num_experts), self.top_k)
+            topk = topk.view(probs.shape[:-1] + (self.top_k,))
         else:
-            idx = probs.argmax(dim=-1)
-        dispatch_mask = F.one_hot(idx, self.num_experts).type_as(probs)
+            topk = probs.topk(self.top_k, dim=-1).indices
+        dispatch_mask = F.one_hot(topk, self.num_experts).sum(dim=-2).type_as(probs)
         out = 0.0
         for i, expert in enumerate(self.experts):
             out = out + expert(x) * dispatch_mask[..., i : i + 1]
-        self.last_routing = dispatch_mask.float().mean(dim=(0, 1)).detach()
+        dims = tuple(range(dispatch_mask.dim() - 1))
+        self.last_routing = dispatch_mask.float().mean(dim=dims).detach()
         ideal = torch.full_like(self.last_routing, 1.0 / self.num_experts)
         self.aux_loss = F.mse_loss(self.last_routing, ideal)
         return out
@@ -114,11 +112,11 @@ class MoEAdapter(nn.Module):
         logits = self.router(x)
         probs = F.softmax(logits, dim=-1)
         if self.training:
-            idx = torch.multinomial(probs.view(-1, self.num_experts), 1)
-            idx = idx.view(probs.shape[:-1])
+            topk = torch.multinomial(probs.view(-1, self.num_experts), self.top_k)
+            topk = topk.view(probs.shape[:-1] + (self.top_k,))
         else:
-            idx = probs.argmax(dim=-1)
-        dispatch_mask = F.one_hot(idx, self.num_experts).type_as(probs)
+            topk = probs.topk(self.top_k, dim=-1).indices
+        dispatch_mask = F.one_hot(topk, self.num_experts).sum(dim=-2).type_as(probs)
         out = 0.0
         for i, expert in enumerate(self.experts):
             out = out + expert(x) * dispatch_mask[..., i : i + 1]
@@ -126,7 +124,8 @@ class MoEAdapter(nn.Module):
         if self.skip_connect:
             out = out + x
         out = self.drop_path(out)
-        self.last_routing = dispatch_mask.float().mean(dim=(0, 1)).detach()
+        dims = tuple(range(dispatch_mask.dim() - 1))
+        self.last_routing = dispatch_mask.float().mean(dim=dims).detach()
         ideal = torch.full_like(self.last_routing, 1.0 / self.num_experts)
         self.aux_loss = F.mse_loss(self.last_routing, ideal)
         return out

--- a/blsamustinyMoe/networks/models/segment_anything_samus_moe/modeling/moe_samus.py
+++ b/blsamustinyMoe/networks/models/segment_anything_samus_moe/modeling/moe_samus.py
@@ -1,9 +1,10 @@
 import torch
 from torch import nn
-from typing import Any, Tuple
+from typing import Any
 
 from .samus import Samus
 from .moe_layers import MoEAdapter
+from .common import Adapter
 
 
 class MoESamus(nn.Module):
@@ -13,47 +14,30 @@ class MoESamus(nn.Module):
         super().__init__()
         self.samus = samus
         self.moe_modules = []
-        self._convert(moe_expert_num, top_k, router_temp)
+        self._replace_adapters(self.samus.image_encoder, moe_expert_num, top_k, router_temp)
 
-    def _convert(self, num_experts: int, top_k: int, temp: float) -> None:
-        enc = self.samus.image_encoder
-        base_adp = enc.input_Adapter
-        enc.input_Adapter = MoEAdapter(
-            base_adp.D_fc1.in_features,
-            mlp_ratio=base_adp.D_fc1.out_features / base_adp.D_fc1.in_features,
-            num_experts=num_experts,
-            top_k=top_k,
-            temperature=temp,
-            skip_connect=True,
-            drop_path=0.0,
-        )
-        enc.input_Adapter.experts[0].load_state_dict(base_adp.state_dict())
-        with torch.no_grad():
-            enc.input_Adapter.router.linear.weight.data.zero_()
-            enc.input_Adapter.router.linear.bias.data.fill_(-10.0)
-            enc.input_Adapter.router.linear.bias.data[0] = 10.0
-        self.moe_modules.append(enc.input_Adapter)
-        total = len(enc.layers)
-        for i, blk in enumerate(enc.layers):
-            if blk.window_size == 0:
-                ar = blk.MLP_Adapter
-                ratio_a = ar.D_fc1.out_features / ar.D_fc1.in_features
-                moe_adp = MoEAdapter(
-                    ar.D_fc1.in_features,
-                    mlp_ratio=ratio_a,
+    def _replace_adapters(self, module: nn.Module, num_experts: int, top_k: int, temp: float) -> None:
+        for name, child in module.named_children():
+            if isinstance(child, Adapter):
+                ratio = child.D_fc1.out_features / child.D_fc1.in_features
+                moe = MoEAdapter(
+                    child.D_fc1.in_features,
+                    mlp_ratio=ratio,
                     num_experts=num_experts,
                     top_k=top_k,
                     temperature=temp,
-                    skip_connect=False,
-                    drop_path=0.2 if i >= total // 2 else 0.0,
+                    skip_connect=child.skip_connect,
+                    drop_path=0.0,
                 )
-                moe_adp.experts[0].load_state_dict(ar.state_dict())
+                moe.experts[0].load_state_dict(child.state_dict())
                 with torch.no_grad():
-                    moe_adp.router.linear.weight.data.zero_()
-                    moe_adp.router.linear.bias.data.fill_(-10.0)
-                    moe_adp.router.linear.bias.data[0] = 10.0
-                blk.MLP_Adapter = moe_adp
-                self.moe_modules.append(moe_adp)
+                    moe.router.linear.weight.zero_()
+                    moe.router.linear.bias.fill_(-10.0)
+                    moe.router.linear.bias[0] = 10.0
+                setattr(module, name, moe)
+                self.moe_modules.append(moe)
+            else:
+                self._replace_adapters(child, num_experts, top_k, temp)
 
     def forward(self, *args: Any, **kwargs: Any) -> Any:
         return self.samus(*args, **kwargs)

--- a/blsamustinyMoe/omni_test.py
+++ b/blsamustinyMoe/omni_test.py
@@ -16,10 +16,11 @@ from datasets.dataset import USdatasetCls, USdatasetSeg
 
 from utils import omni_seg_test
 from sklearn.metrics import accuracy_score
-# 在文件开头添加
-USE_SAMUS = True  # 与训练时保持一致
 
-if USE_SAMUS:
+# 与训练脚本保持一致，默认使用带 MoE 的 SAMUS
+USE_SAMUS_MOE = True
+
+if USE_SAMUS_MOE:
     from networks.samus_adapter import SAMUSAdapter as ModelClass
 else:
     from networks.omni_vision_transformer import OmniVisionTransformer as ModelClass

--- a/blsamustinyMoe/omni_train.py
+++ b/blsamustinyMoe/omni_train.py
@@ -4,10 +4,11 @@ import random
 import numpy as np
 import torch
 import torch.backends.cudnn as cudnn
-# 选择使用的模型
-USE_SAMUS = True  # 设置为 True 使用 SAMUS，False 使用原始 ViT_omni
 
-if USE_SAMUS:
+# 选择使用的模型
+USE_SAMUS_MOE = True  # True 使用带 MoE 的 SAMUS，False 使用原始 ViT_omni
+
+if USE_SAMUS_MOE:
     from networks.samus_adapter import SAMUSAdapter as ModelClass
 else:
     from networks.omni_vision_transformer import OmniVisionTransformer as ModelClass


### PR DESCRIPTION
## Summary
- add Router and MoEAdapter utilities to handle expert routing
- recursively swap baseline adapters with MoE versions inside SAMUS
- expose MoE components via modeling package exports

## Testing
- `python -m py_compile blsamustinyMoe/networks/models/segment_anything_samus_moe/modeling/moe_layers.py blsamustinyMoe/networks/models/segment_anything_samus_moe/modeling/moe_samus.py blsamustinyMoe/networks/models/segment_anything_samus_moe/modeling/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_689b2a125334832b87874efc5e9c96a5