### PR TITLE
Flatten inputs before routing in MoE adapter

### DIFF
--- a/blsamustinyMoe/networks/models/segment_anything_samus_moe/modeling/moe_layers.py
+++ b/blsamustinyMoe/networks/models/segment_anything_samus_moe/modeling/moe_layers.py
@@ -109,7 +109,9 @@ class MoEAdapter(nn.Module):
         self.last_routing = None
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        logits = self.router(x)
+        orig_shape = x.shape
+        x_flat = x.view(-1, x.shape[-1])
+        logits = self.router(x_flat).view(orig_shape[:-1] + (self.num_experts,))
         probs = F.softmax(logits, dim=-1)
         if self.training:
             topk = torch.multinomial(probs.view(-1, self.num_experts), self.top_k)
@@ -119,7 +121,8 @@ class MoEAdapter(nn.Module):
         dispatch_mask = F.one_hot(topk, self.num_experts).sum(dim=-2).type_as(probs)
         out = 0.0
         for i, expert in enumerate(self.experts):
-            out = out + expert(x) * dispatch_mask[..., i : i + 1]
+            expert_out = expert(x_flat).view(orig_shape)
+            out = out + expert_out * dispatch_mask[..., i : i + 1]
         out = self.dropout(out)
         if self.skip_connect:
             out = out + x


### PR DESCRIPTION
## Summary
- Flatten adapter inputs before routing and expert processing in `MoEAdapter`
- Reshape router logits and expert outputs back to original shape for mixing

## Testing
- `python - <<'PY'
import torch
from blsamustinyMoe.networks.models.segment_anything_samus_moe.modeling.moe_layers import MoEAdapter
adapter = MoEAdapter(dim=16, num_experts=4, top_k=1)
adapter.train()
x = torch.randn(2,3,16)
out = adapter(x)
print('out shape', out.shape)
print('aux loss', adapter.get_aux_loss().item())
PY`

------
https://chatgpt.com/codex/tasks/task_e_689dc35ee84c832bb21de7e05f6148ba