### PR TITLE
Ensure TinyViT SAM uses channel-first tensors after input adapter

### DIFF
--- a/blsamustinyMoe/networks/models/segment_anything_samus_moe/modeling/tiny_vit_sam.py
+++ b/blsamustinyMoe/networks/models/segment_anything_samus_moe/modeling/tiny_vit_sam.py
@@ -772,7 +772,9 @@ class TinyViT(nn.Module):
     def forward_features(self, x):
         # x: (N, C, H, W)
         x = self.patch_embed(x) # 4 3 224 224
+        x = x.permute(0, 2, 3, 1).contiguous()
         x = self.input_Adapter(x)
+        x = x.permute(0, 3, 1, 2).contiguous()
 
         x = self.layers[0](x)
         start_i = 1


### PR DESCRIPTION
## Summary
- Preserve channel-first layout for TinyViT-SAM backbone by permuting to HWC for `input_Adapter` then back to CHW

## Testing
- `python3 -m py_compile blsamustinyMoe/networks/models/segment_anything_samus_moe/modeling/tiny_vit_sam.py`


------
https://chatgpt.com/codex/tasks/task_e_689ddf56a7a8832b9e638e5a2572b2a3