### PR TITLE
Integrate MoEAdapter in TinyViT input path

### DIFF
--- a/blsamustinyMoe/networks/models/segment_anything_samus_moe/modeling/tiny_vit_sam.py
+++ b/blsamustinyMoe/networks/models/segment_anything_samus_moe/modeling/tiny_vit_sam.py
@@ -19,6 +19,7 @@ from typing import Tuple
 from typing import Optional, Tuple, Type
 
 from .common import LayerNorm2d, MLPBlock, Adapter, AugAdapter
+from .moe_layers import MoEAdapter
 import math
 
 class Conv2d_BN(torch.nn.Sequential):
@@ -721,7 +722,7 @@ class TinyViT(nn.Module):
             ),
             LayerNorm2d(256),
         )
-        self.input_Adapter = Adapter(embed_dim)
+        self.input_Adapter = MoEAdapter(dim=embed_dim)
     def set_layer_lr_decay(self, layer_lr_decay):
         decay_rate = layer_lr_decay
 
@@ -771,10 +772,10 @@ class TinyViT(nn.Module):
 
     def forward_features(self, x):
         # x: (N, C, H, W)
-        x = self.patch_embed(x) # 4 3 224 224
-        x = x.permute(0, 2, 3, 1).contiguous()
+        x = self.patch_embed(x)  # 4 3 224 224
+        x = x.permute(0, 2, 3, 1).contiguous()  # [B, H, W, C]
         x = self.input_Adapter(x)
-        x = x.permute(0, 3, 1, 2).contiguous()
+        x = x.permute(0, 3, 1, 2).contiguous()  # [B, C, H, W]
 
         x = self.layers[0](x)
         start_i = 1


### PR DESCRIPTION
## Summary
- Import MoEAdapter and instantiate it for TinyViT's input adapter
- Permute patches to channel-last, apply MoEAdapter, then restore channel-first format in `forward_features`

## Testing
- `python -m py_compile blsamustinyMoe/networks/models/segment_anything_samus_moe/modeling/tiny_vit_sam.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hausdorff'; ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689deac653ac832b827c7dcc2014de48